### PR TITLE
Fixing linter mistake

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Owners of Repo
+* @edx/devops

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="zappa-manage",
-    version="0.0.2",
+    version="0.0.3",
     author="edX-DevOps",
     author_email="devops@edx.org",
     description="Official Manage Package for edX Zappa Bots",

--- a/zappa_manage/__init__.py
+++ b/zappa_manage/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-import boto
+import boto3
 import click
 from pybase64 import b64encode
 


### PR DESCRIPTION
My linter never caught the unknown package mistake: `import boto vs import boto3`